### PR TITLE
Adds Homebrew Arm64 OpenSSL Path

### DIFF
--- a/src/reload.lisp
+++ b/src/reload.lisp
@@ -44,6 +44,7 @@
   (:darwin (:or "/opt/local/lib/libcrypto.dylib" ;; MacPorts
                 "/sw/lib/libcrypto.dylib"        ;; Fink
                 "/usr/local/opt/openssl/lib/libcrypto.dylib" ;; Homebrew
+                "/opt/homebrew/opt/openssl/lib/libcrypto.dylib" ;; Homebrew Arm64
                 "/usr/local/lib/libcrypto.dylib" ;; personalized install
                 "/usr/lib/libcrypto.44.dylib"
                 "/usr/lib/libcrypto.42.dylib"


### PR DESCRIPTION
The Homebrew path for openssl is different for arm64 than the path for x86_64.  This adds one more tire to the fire.